### PR TITLE
fix issue with compiling due to duplicate symbols in math.h

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,20 @@ use bindgen::builder;
 
 use std::env;
 use std::path::PathBuf;
+use std::collections::HashSet;
+
+#[derive(Debug)]
+struct IgnoreMacros(HashSet<String>);
+
+impl bindgen::callbacks::ParseCallbacks for IgnoreMacros {
+    fn will_parse_macro(&self, name: &str) -> bindgen::callbacks::MacroParsingBehavior {
+        if self.0.contains(name) {
+            bindgen::callbacks::MacroParsingBehavior::Ignore
+        } else {
+            bindgen::callbacks::MacroParsingBehavior::Default
+        }
+    }
+}
 
 fn main() {
     println!("cargo:rustc-link-lib=gvc");
@@ -9,9 +23,22 @@ fn main() {
     println!("cargo:rustc-link-lib=pathplan");
     println!("cargo:rustc-link-lib=cdt");
 
+    let ignored_macros = IgnoreMacros(
+                vec![
+                    "FP_INFINITE".into(),
+                    "FP_NAN".into(),
+                    "FP_NORMAL".into(),
+                    "FP_SUBNORMAL".into(),
+                    "FP_ZERO".into(),
+                ]
+                .into_iter()
+                .collect(),
+            );
+
     let bindings =
         builder()
             .header("./wrapper.h")
+            .parse_callbacks(Box::new(ignored_macros))
             .generate()
             .expect("Unable to generate bindings");
 


### PR DESCRIPTION
I was unable to build the library because of an issue with colliding enum/macros in math.h.  I found and implemented https://github.com/rust-lang/rust-bindgen/issues/687#issuecomment-450750547 which solves the problem.  